### PR TITLE
bump electron deps to latest; add relative path to npm script binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spin",
   "productName": "Spin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "YouTube Music Player",
   "keywords": ["youtube", "music", "player", "electron", "material"],
   "homepage": "https://github.com/gangoffork/spin#readme",
@@ -15,9 +15,9 @@
     "url": "https://github.com/gangoffork/spin/issues"
   },
   "scripts": {
-    "test": "xo",
-    "start": "electron .",
-    "build": "electron-packager . --out=dist --app-version=$npm_package_version --prune --asar --overwrite --all"
+    "test": "node_modules/.bin/xo",
+    "start": "node_modules/.bin/electron .",
+    "build": "node_modules/.bin/electron-packager . --out=dist --prune --asar --overwrite --all"
   },
   "files": [
     "index.js",
@@ -25,15 +25,15 @@
     "index.css"
   ],
   "dependencies": {
-    "electron-debug": "^0.6.0"
+    "electron-debug": "^1.0.1"
   },
   "devDependencies": {
-    "electron-packager": "^7.0.0",
-    "electron-prebuilt": "^0.37.5",
-    "xo": "^0.14.0"
+    "electron-packager": "^8.0.0",
+    "electron-prebuilt": "^1.3.5",
+    "xo": "^0.16.0"
   },
   "xo": {
     "esnext": true,
-    "envs": [ "node", "browser" ]
+    "envs": ["node", "browser"]
   }
 }


### PR DESCRIPTION
@gangoffork/fellas, this one has come due to those complaints from @FranciscoMarinho when he tried to build spin for all platforms. I did some changes, anyway, but didn't managed to get stuck at all. 
From everything I could see, `electron-packager` dep changed its way to build Windows binaries from Unix-based platforms, requiring a globally visible `wine` binary for that.
By the way, I updated some deps versions and changed npm scripts to use their local binaries. It might be something good.
